### PR TITLE
Service probes

### DIFF
--- a/squid_control/uc2_fucci_illumination_configurations.xml
+++ b/squid_control/uc2_fucci_illumination_configurations.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <modes>
-  <mode ID="1" Name="BF LED matrix full" ExposureTime="26.0" AnalogGain="1.0999999999999999" IlluminationSource="0" IlluminationIntensity="28.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
+  <mode ID="1" Name="BF LED matrix full" ExposureTime="20.0" AnalogGain="1.0999999999999999" IlluminationSource="0" IlluminationIntensity="28.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="2" Name="BF LED matrix left half" ExposureTime="30.0" AnalogGain="0.5" IlluminationSource="1" IlluminationIntensity="56.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="3" Name="BF LED matrix right half" ExposureTime="20.0" AnalogGain="0" IlluminationSource="2" IlluminationIntensity="23.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="4" Name="BF LED matrix color PDAF" ExposureTime="22" AnalogGain="0" IlluminationSource="3" IlluminationIntensity="59.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -935,6 +935,10 @@ class Microscope:
         logger.info(f"Extension service registered with id: {svc.id}, you can visit the service at:\n {self.chatbot_service_url}")
 
     async def setup(self):
+        data_store_token = os.environ.get("SQUID_WORKSPACE_TOKEN")
+        data_store_server = await connect_to_server(
+                {"server_url": "https://hypha.aicell.io", "token": data_store_token, "workspace": "squid-control", "ping_interval": None}
+            )
         if not self.service_id:
             raise ValueError("MICROSCOPE_SERVICE_ID is not set in the environment variables.")
         if self.is_local:
@@ -962,12 +966,12 @@ class Microscope:
             chatbot_id = f"squid-control-chatbot-real-{self.service_id}"
         self.datastore = HyphaDataStore()
         try:
-            await self.datastore.setup(server, service_id=datastore_id)
+            await self.datastore.setup(data_store_server, service_id=datastore_id)
         except TypeError as e:
             if "Future" in str(e):
                 # If config is a Future, wait for it to resolve
                 config = await asyncio.wrap_future(server.config)
-                await self.datastore.setup(server, service_id=datastore_id, config=config)
+                await self.datastore.setup(data_store_server, service_id=datastore_id, config=config)
             else:
                 raise e
     

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -946,12 +946,12 @@ class Microscope:
             )
         else:
             try:  
-                token = os.environ.get("REEF_WORKSPACE_TOKEN")  
+                token = os.environ.get("SQUID_WORKSPACE_TOKEN")  
             except:  
                 token = await login({"server_url": self.server_url})
             
             server = await connect_to_server(
-                {"server_url": self.server_url, "token": token, "workspace": "reef-imaging",  "ping_interval": None}
+                {"server_url": self.server_url, "token": token, "workspace": "squid-control",  "ping_interval": None}
             )
         if self.is_simulation:
             await self.start_hypha_service(server, service_id=self.service_id)

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -213,10 +213,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to move by distance: {e}")
-            return {
-                "success": False,
-                "message": f"Failed to move by distance: {e}"
-            }
+            raise e
 
     @schema_function(skip_self=True)
     def move_to_position(self, x:float=Field(1.0,description="Unit: milimeter"), y:float=Field(1.0,description="Unit: milimeter"), z:float=Field(1.0,description="Unit: milimeter"), context=None):
@@ -275,10 +272,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to move to position: {e}")
-            return {
-                "success": False,
-                "message": f"Failed to move to position: {e}"
-            }
+            raise e
 
     @schema_function(skip_self=True)
     def get_status(self, context=None):
@@ -315,7 +309,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to get status: {e}")
-            return {}
+            raise e
 
     @schema_function(skip_self=True)
     def update_parameters_from_client(self, new_parameters: dict=Field(description="the dictionary parameters user want to update"), context=None):
@@ -348,7 +342,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to update parameters: {e}")
-            return {"success": False, "message": f"Failed to update parameters: {e}"}
+            raise e
 
     @schema_function(skip_self=True)
     async def one_new_frame(self, exposure_time: int=Field(100, description="Exposure time in milliseconds"), channel: int=Field(0, description="Light source (0 for Bright Field, Fluorescence channels: 11 for 405 nm, 12 for 488 nm, 13 for 638nm, 14 for 561 nm, 15 for 730 nm)"), intensity: int=Field(50, description="Light intensity"), context=None):
@@ -398,7 +392,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to get new frame: {e}")
-            return None
+            raise e
 
     @schema_function(skip_self=True)
     async def snap(self, exposure_time: int=Field(100, description="Exposure time, in milliseconds"), channel: int=Field(0, description="Light source (0 for Bright Field, Fluorescence channels: 11 for 405 nm, 12 for 488 nm, 13 for 638nm, 14 for 561 nm, 15 for 730 nm)"), intensity: int=Field(50, description="Intensity of the illumination source"), context=None):
@@ -442,7 +436,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to snap image: {e}")
-            return None
+            raise e
 
     @schema_function(skip_self=True)
     def open_illumination(self, context=None):
@@ -460,7 +454,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to open illumination: {e}")
-            return f"Failed to open illumination: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def close_illumination(self, context=None):
@@ -478,7 +472,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to close illumination: {e}")
-            return f"Failed to close illumination: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def scan_well_plate(self, well_plate_type: str=Field("96", description="Type of the well plate (e.g., '6', '12', '24', '96', '384')"), illuminate_channels: List[str]=Field(default_factory=lambda: ['BF LED matrix full','Fluorescence 488 nm Ex','Fluorescence 561 nm Ex'], description="Light source to illuminate the well plate"), do_contrast_autofocus: bool=Field(False, description="Whether to do contrast based autofocus"), do_reflection_af: bool=Field(True, description="Whether to do reflection based autofocus"), scanning_zone: List[tuple]=Field(default_factory=lambda: [(0,0),(0,0)], description="The scanning zone of the well plate, for 91 well plate, it should be[(0,0),(7,11)] "), Nx: int=Field(3, description="Number of columns to scan"), Ny: int=Field(3, description="Number of rows to scan"), action_ID: str=Field('testPlateScan', description="The ID of the action"), context=None):
@@ -499,7 +493,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to scan well plate: {e}")
-            return f"Failed to scan well plate: {e}"
+            raise e
     
     @schema_function(skip_self=True)
     def scan_well_plate_simulated(self, context=None):
@@ -516,7 +510,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to scan well plate: {e}")
-            return f"Failed to scan well plate: {e}"
+            raise e
 
 
     @schema_function(skip_self=True)
@@ -535,7 +529,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to set illumination: {e}")
-            return f"Failed to set illumination: {e}"
+            raise e
     
     @schema_function(skip_self=True)
     def set_camera_exposure(self, exposure_time: int=Field(100, description="Exposure time in milliseconds"), context=None):
@@ -553,7 +547,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to set camera exposure: {e}")
-            return f"Failed to set camera exposure: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def stop_scan(self, context=None):
@@ -572,7 +566,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to stop scan: {e}")
-            return f"Failed to stop scan: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def home_stage(self, context=None):
@@ -590,7 +584,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to home stage: {e}")
-            return f"Failed to home stage: {e}"
+            raise e
     
     @schema_function(skip_self=True)
     def return_stage(self,context=None):
@@ -608,7 +602,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to return stage: {e}")
-            return f"Failed to return stage: {e}"
+            raise e
     
     @schema_function(skip_self=True)
     def move_to_loading_position(self, context=None):
@@ -626,7 +620,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to move to loading position: {e}")
-            return f"Failed to move to loading position: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def auto_focus(self, context=None):
@@ -644,7 +638,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to auto focus: {e}")
-            return f"Failed to auto focus: {e}"
+            raise e
     
     @schema_function(skip_self=True)
     def do_laser_autofocus(self, context=None):
@@ -662,7 +656,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to do laser autofocus: {e}")
-            return f"Failed to do laser autofocus: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def navigate_to_well(self, row: str=Field('A', description="Row number of the well position (e.g., 'A')"), col: int=Field(1, description="Column number of the well position"), wellplate_type: str=Field('96', description="Type of the well plate (e.g., '6', '12', '24', '96', '384')"), context=None):
@@ -682,7 +676,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to navigate to well: {e}")
-            return f"Failed to navigate to well: {e}"
+            raise e
 
     @schema_function(skip_self=True)
     def get_chatbot_url(self, context=None):
@@ -699,7 +693,7 @@ class Microscope:
         except Exception as e:
             self.task_status[task_name] = "failed"
             logger.error(f"Failed to get chatbot URL: {e}")
-            return None
+            raise e
     
     class MoveByDistanceInput(BaseModel):
         """Move the stage by a distance in x, y, z axis."""

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -939,17 +939,18 @@ class Microscope:
             raise ValueError("MICROSCOPE_SERVICE_ID is not set in the environment variables.")
         if self.is_local:
             token = os.environ.get("REEF_LOCAL_TOKEN")
+            workspace = os.environ.get("REEF_LOCAL_WORKSPACE")
             server = await connect_to_server(
-                {"server_url": self.server_url, "token": token,  "ping_interval": None}
+                {"server_url": self.server_url, "token": token, "workspace": workspace, "ping_interval": None}
             )
         else:
             try:  
-                token = os.environ.get("SQUID_WORKSPACE_TOKEN")  
+                token = os.environ.get("REEF_WORKSPACE_TOKEN")  
             except:  
                 token = await login({"server_url": self.server_url})
             
             server = await connect_to_server(
-                {"server_url": self.server_url, "token": token, "workspace": "squid-control",  "ping_interval": None}
+                {"server_url": self.server_url, "token": token, "workspace": "reef-imaging",  "ping_interval": None}
             )
         if self.is_simulation:
             await self.start_hypha_service(server, service_id=self.service_id)

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -1032,8 +1032,8 @@ class Microscope:
         
         logger.info("Registering health probes for Kubernetes")
         await server.register_probes({
-            "readiness": is_service_healthy,
-            "liveness": is_service_healthy
+            f"readiness-{self.service_id}": is_service_healthy,
+            f"liveness-{self.service_id}": is_service_healthy
         })
         logger.info("Health probes registered successfully")
 

--- a/uc2_fucci_illumination_configurations.xml
+++ b/uc2_fucci_illumination_configurations.xml
@@ -1,6 +1,6 @@
 <?xml version='1.0' encoding='UTF-8'?>
 <modes>
-  <mode ID="1" Name="BF LED matrix full" ExposureTime="26.0" AnalogGain="1.0999999999999999" IlluminationSource="0" IlluminationIntensity="28.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
+  <mode ID="1" Name="BF LED matrix full" ExposureTime="18.0" AnalogGain="1.0999999999999999" IlluminationSource="0" IlluminationIntensity="28.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="2" Name="BF LED matrix left half" ExposureTime="30.0" AnalogGain="0.5" IlluminationSource="1" IlluminationIntensity="56.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="3" Name="BF LED matrix right half" ExposureTime="20.0" AnalogGain="0" IlluminationSource="2" IlluminationIntensity="23.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>
   <mode ID="4" Name="BF LED matrix color PDAF" ExposureTime="22" AnalogGain="0" IlluminationSource="3" IlluminationIntensity="59.0" CameraSN="" ZOffset="0.0" PixelFormat="default" _PixelFormat_options="[default,MONO8,MONO12,MONO14,MONO16,BAYER_RG8,BAYER_RG12]"/>


### PR DESCRIPTION
This pull request introduces changes to improve error handling, enhance service setup functionality, and optimize configurations. The most significant updates include replacing return statements with exception raising for better error propagation, adding Kubernetes health probes for service monitoring, and modifying service setup to include additional environment variables and server connections.

### Error Handling Improvements:
* Replaced return statements with `raise e` in multiple methods across `start_hypha_service.py` to ensure exceptions are propagated instead of being silently handled. This affects methods such as `move_by_distance`, `move_to_position`, `get_status`, and others. 

### Service Setup Enhancements:
* Added Kubernetes health probes by implementing a new method `register_service_probes` to monitor the readiness and liveness of services. This includes checks for the microscope, datastore, and chatbot services.
* Enhanced the `setup` method to include additional environment variables (`SQUID_WORKSPACE_TOKEN`, `REEF_LOCAL_WORKSPACE`) and establish a connection to the data store server. [[1]](diffhunk://#diff-4df293360ee016d114b5ed554124cce6891bcb3523a40617bd028a88ea10c919R935-R945) [[2]](diffhunk://#diff-4df293360ee016d114b5ed554124cce6891bcb3523a40617bd028a88ea10c919L964-R971)

### Configuration Optimization:
* Updated the exposure time for mode ID 1 in `uc2_fucci_illumination_configurations.xml` from 26.0 to 20.0 for better performance.

These changes collectively improve error visibility, enhance service reliability, and optimize configurations for better system performance.