### PR TITLE
Updates for service probe & laser autofocus

### DIFF
--- a/squid_control/control/core_reef.py
+++ b/squid_control/control/core_reef.py
@@ -3773,6 +3773,7 @@ class LaserAutofocusController(QObject):
         self.wait_till_operation_is_completed()
         self.x_reference = x
         self.initialize_manual(self.x_offset, self.y_offset, self.width, self.height, self.pixel_to_um, self.x_reference,write_to_cache=True)
+        self.wait_till_operation_is_completed()
         self.signal_displacement_um.emit(0)
 
     def _caculate_centroid(self, image):

--- a/start_hypha_service.py
+++ b/start_hypha_service.py
@@ -1097,7 +1097,8 @@ class Microscope:
                         test_result = await asyncio.wait_for(
                             self.squidController.camera.zarr_image_manager.test_zarr_access(
                                 dataset_id="agent-lens/20250506-scan-time-lapse-2025-05-06_17-56-38",
-                                channel="BF_LED_matrix_full"
+                                channel="BF_LED_matrix_full",
+                                bypass_cache=True
                             ), 
                             50
                         ) 


### PR DESCRIPTION

### Laser Reference Feature:
* Added a new `set_laser_reference` function in `start_hypha_service.py`, which sets the laser reference and updates task status. This introduces a new operation for laser calibration.
* Registered the `set_laser_reference` function in the service's task map, making it accessible as part of the service's operations.

### Service Health and Registration Updates:
* Adjusted health probe registration logic to exclude services with "local" in their service ID, ensuring probes are only registered for non-local services.
* Updated the `is_service_healthy` method to bypass metadata cache during health checks, ensuring accurate validation of service health.